### PR TITLE
Add Racket solution to square list multikata

### DIFF
--- a/multikata/square_list_equal/README.adoc
+++ b/multikata/square_list_equal/README.adoc
@@ -266,3 +266,22 @@ is to verbose.
 
 We have to deal with `null`, the billion dollar error. https://en.wikipedia.org/wiki/Tony_Hoare
 
+== Racket
+
+[source, racket]
+----
+#lang racket/base
+
+(define (comp a b)
+  (let ([sqr (lambda (x) (* x x))])
+    (equal? (sort (map sqr a) <) (sort b <))))
+----
+
+The solution file contains tests. You can run them as follows:
+
+[source, console]
+----
+$ raco test racket/solution.rkt
+raco test: (submod "racket/solution.rkt" test)
+6 tests passed
+----

--- a/multikata/square_list_equal/racket/solution.rkt
+++ b/multikata/square_list_equal/racket/solution.rkt
@@ -1,0 +1,29 @@
+#lang racket/base
+
+(define (comp a b)
+  (let ([sqr (lambda (x) (* x x))])
+    (equal? (sort (map sqr a) <) (sort b <))))
+
+(module+ test
+  (require rackunit)
+  (test-case
+      "Compare tests"
+    (let ([a '(1 2 3 4)]
+          [b '(1 4 9 16)])
+      (check-true (comp a b)))
+    (let ([a '(2 3 1 4)]
+          [b '(16 4 9 1)])
+      (check-true (comp a b)))
+    (let ([a '(1 2 3 4)]
+          [b '(1 4 9)])
+      (check-false (comp a b)))
+    (let ([a '(1 2 3 4 4)]
+          [b '(1 4 9 16 16)])
+      (check-true (comp a b)))
+    (let ([a '(1 2 3 4 4)]
+          [b '(1 4 9 16)])
+      (check-false (comp a b)))
+    ;; introduced to fully define kata
+    (let ([a '(1 2 3)]
+          [b '(1 4 25)])
+      (check-false (comp a b)))))


### PR DESCRIPTION
Adds a racket directory with a single file that holds both the solution and some tests to check for sanity. The tests are those defined in the README, plus one more in order to require the implementation to actually check inside the lists' contents.