### PR TITLE
Type Racket solution to multikata square list

### DIFF
--- a/multikata/square_list_equal/racket/solution.rkt
+++ b/multikata/square_list_equal/racket/solution.rkt
@@ -1,11 +1,17 @@
 #lang racket/base
 
-(define (comp a b)
-  (let ([sqr (lambda (x) (* x x))])
+(module supersecure typed/racket/base
+  (provide comp)
+
+  (: comp (-> (Listof Integer) (Listof Integer) Boolean))
+  (define (comp a b)
+    (: sqr (-> Integer Integer))
+    (define (sqr x) (* x x))
     (equal? (sort (map sqr a) <) (sort b <))))
 
-(module+ test
+(module test racket/base
   (require rackunit)
+  (require (submod ".." supersecure))
   (test-case
       "Compare tests"
     (let ([a '(1 2 3 4)]
@@ -26,4 +32,12 @@
     ;; introduced to fully define kata
     (let ([a '(1 2 3)]
           [b '(1 4 25)])
-      (check-false (comp a b)))))
+      (check-false (comp a b))))
+  (test-case
+      "Typing tests"
+    (check-exn exn:fail:contract? (lambda () (comp '(a b c) '(1 2 3))))
+    (check-exn exn:fail:contract? (lambda () (comp '(a b c) '(a b c))))
+    (check-exn exn:fail:contract? (lambda () (comp '(1 2 3) '(a b c))))
+    (check-exn exn:fail:contract? (lambda () (comp '(1.0 2.0) '(1.0 4.0))))
+    (check-exn exn:fail:contract? (lambda () (comp 2 4)))
+    (check-exn exn:fail:contract? (lambda () (comp (vector 1 2 3) (vector 1 4 9))))))


### PR DESCRIPTION
Show off the ability of Racket to be multiple languages at the same time by typing only the part of the solution module that holds the `comp` function.  The tests are still untyped Racket code. There is a new test-case that checks that now only lists of integer numbers can cross the typed/untyped boundary without causing a contract exception.

The internal definition of `sqr` is now in a `define` form instead of a lambda receiving a name within a `let`. The Racket compiler did not behave well with just a type annotation on top of `comp`, but probably the unchanged code would have worked with some more type hints within its body.